### PR TITLE
fix(platform-check)

### DIFF
--- a/src/vault.py
+++ b/src/vault.py
@@ -189,7 +189,7 @@ class Envs:
                 if self.args.verbose is True:
                     print("The editor is: " + editor)
             except AttributeError:
-                if platform.system() is not "Windows":
+                if platform.system() != "Windows":
                     editor = "vi"
                     if self.args.verbose is True:
                         print("The default editor is: " + editor)


### PR DESCRIPTION
Fix python error when comparing strings with "is not" operator

# Pull Request Template

## Description

When trying to launch the script via helm vault, the comparison failed because of the wrong operator being used


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Python Version: 3.8
* Vault Version: latest

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Mentions:

@Just-Insane
